### PR TITLE
Make TLS and user auth optional when sending email.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ to `/opt/stackstorm/configs/email.yaml` and edit as required.
 
 Configure values as described in the sections below.
 
+# Actions
+
+### send_email
+
+When sending email the configuration option `starttls` can be used to enable TLS
+for the connection.  `smtp_auth` is used to control if user authentication is required before
+sending the message to the SMTP server.
+
 ## Sensors
 ### SMTP Sensor
 

--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -26,8 +26,10 @@ class SendEmail(Action):
 
         s = SMTP(account_data['server'], int(account_data['port']), timeout=20)
         s.ehlo()
-        s.starttls()
-        s.login(account_data['username'], account_data['password'])
+        if account_data.get('starttls', True) is True:
+            s.starttls()
+        if account_data.get('smtp_auth', True) is True:
+            s.login(account_data['username'], account_data['password'])
         s.sendmail(email_from, email_to, msg.as_string())
         s.quit()
         return

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -29,10 +29,18 @@ imap_mailboxes:
         description: "Set to False to disable SSL. Default True"
         type: "boolean"
         default: true
+      smtp_auth:
+        description: "Authenticate username and password with SMTP server to send email. Default True"
+        type: "boolean"
+        default: true
+      starttls:
+        description: "Use TLS for the connection to the SMTP server when sending email. Default True"
+        type: "boolean"
+        default: true
       download_attachments:
         description: "Set to True to download attachments to datastore. Default False"
         type: "boolean"
-        default: False
+        default: false
       folder:
         description: "Folder to check for email. Default INBOX"
         type: "string"
@@ -48,7 +56,7 @@ attachment_datastore_ttl:
   type: "integer"
   required: false
   default: 1800
-smtp_listen_ip: 
+smtp_listen_ip:
   description: "IP address to for SMTP sensor to listen on"
   type: "string"
   required: false

--- a/email.yaml.example
+++ b/email.yaml.example
@@ -6,7 +6,9 @@ imap_mailboxes:
     username: "lindsay@stackstorm.com"
     password: "super_S3c4e3t!"
     ssl: true
-    download_attachments: True
+    download_attachments: true
+    starttls: true
+    smtp_auth: true
 max_attachment_size: 1024
 attachment_datastore_ttl: 1800
 smtp_listen_ip: '127.0.0.1'


### PR DESCRIPTION
This patch makes TLS and user auth optional when sending via SMTP using send_email action.