### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ to `/opt/stackstorm/configs/email.yaml` and edit as required.
 
 Configure values as described in the sections below.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Sensors
 ### SMTP Sensor
 

--- a/actions/send_email.yaml
+++ b/actions/send_email.yaml
@@ -1,6 +1,6 @@
 ---
   name: "send_email"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Send an email."
   enabled: true
   entry_point: "send_email.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - email
   - messaging
   - imap
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.