### PR TITLE
Adjust email_to data type to fix multiple destinations support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.4.0
+
+- Changed `email_to` data type from string to list in order to support multiple email address
+  destinations.
+
 # 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -21,7 +21,7 @@ class SendEmail(Action):
         msg = MIMEMultipart()
         msg['Subject'] = subject
         msg['From'] = email_from
-        msg['To'] = email_to
+        msg['To'] = ", ".join(email_to)
         msg.attach(MIMEText(message, 'plain'))
 
         s = SMTP(account_data['server'], int(account_data['port']), timeout=20)

--- a/actions/send_email.yaml
+++ b/actions/send_email.yaml
@@ -7,11 +7,11 @@
   parameters:
     email_from:
       type: "string"
-      description: "Email to use as FROM."
+      description: "Email address to use as FROM."
       required: true
     email_to:
-      type: "string"
-      description: "Email to send TO."
+      type: "array"
+      description: "Email addresses to send TO."
       required: true
     subject:
       type: "string"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - email
   - messaging
   - imap
-version: 0.3.0
+version: 0.4.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
**Problem**
Stackstorm only sends an email to the first address when attempting to send to multiple destinations.

**Reason**
The pack passes the variable `email_to` in the form of a string to the Python code.  The Python code uses `smtplib` which treats string types as a single address.  `smtplib` can process multiple addresses if they are supplied in the form of a list.  So passing `email_to` as a string doesn't produce errors, but silent fails for multiple destinations.

The Python code also uses `MIMEMultipart` which calls string methods directly on `email_to`.  If `email_to` is a list, it causes exceptions to be raised.

**Solution**
By changing the data type from `email_to` to _array_, the field better reflects the multiple addresses nature and makes processing the address list simple and unambiguous.

While this is a breaking change, I hope this patch will be accepted as the better solution for the long term.