### PR TITLE
Add attachment support on SendEmail action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.3
+
+- Add `attachments` parameter to the send_email action. Expected a list of file paths if given, to be attached to the email.
+
 # 1.0.2
 
 - Add `mime` parameter to the send_email action.  If the value is `html`, the mime type of the email will be `text/html`.  Otherwise, the mime will be `text/plain`.

--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -35,9 +35,10 @@ class SendEmail(Action):
 
         attachments = attachments or tuple()
         for filepath in attachments:
+            filename = os.path.basename(filepath)
             with open(filepath, 'rb') as f:
-                part = MIMEApplication(f.read(), Name=os.path.basename(filepath))
-            part['Content-Disposition'] = 'attachment; filename="{}"'.format(os.path.basename(filepath))
+                part = MIMEApplication(f.read(), Name=filename)
+            part['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
             msg.attach(part)
 
         s = SMTP(account_data['server'], int(account_data['port']), timeout=20)

--- a/actions/send_email.yaml
+++ b/actions/send_email.yaml
@@ -32,3 +32,6 @@
       enum:
         - "plain"
         - "html"
+    attachments:
+      type: "array"
+      description: "The absolute file path(s) as attachments."

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - email
   - messaging
   - imap
-version: 1.0.2
+version: 1.0.3
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Add `attachments` parameter to the send_email action. Expected a list of file paths if given, to be attached to the email.

Closes #10.