### PR TITLE
Fix unicode error

### DIFF
--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -1,6 +1,7 @@
 import os
 from st2common.runners.base_action import Action
 from smtplib import SMTP
+from email.header import Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -28,10 +29,10 @@ class SendEmail(Action):
                            'Available accounts are: {}'.format(account, ",".join(kv.keys())))
 
         msg = MIMEMultipart()
-        msg['Subject'] = subject
+        msg['Subject'] = Header(subject, 'utf-8')
         msg['From'] = email_from
         msg['To'] = ", ".join(email_to)
-        msg.attach(MIMEText(message, mime))
+        msg.attach(MIMEText(message, mime, 'utf-8'))
 
         attachments = attachments or tuple()
         for filepath in attachments:


### PR DESCRIPTION
How to reproduce this issue:
Just run the action and using Chinese character for subject and message fileds.

`st2 run email.send_email account=esdozer email_to='longfei.zhang@easystack.cn' message='中文正文' subject='中文摘要' email_from='noreply@easystack.cn'`

```
id: 5b22068aa24585000d7cfd75
status: failed
parameters: 
  account: esdozer
  email_from: noreply@easystack.cn
  email_to:
  - longfei.zhang@easystack.cn
  message: "中文正文"
  subject: "中文摘要"
result: 
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 278, in <module>
    obj.run()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 171, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/email/actions/send_email.py", line 34, in run
    msg.attach(MIMEText(message, mime))
  File "/usr/lib64/python2.7/email/mime/text.py", line 30, in __init__
    self.set_payload(_text, _charset)
  File "/usr/lib64/python2.7/email/message.py", line 226, in set_payload
    self.set_charset(charset)
  File "/usr/lib64/python2.7/email/message.py", line 262, in set_charset
    self._payload = self._payload.encode(charset.output_charset)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
"
  stdout: ''
```

After add this fix test again:


```
st2 run email.send_email account=esdozer email_to='longfei.zhang@easystack.cn' message='中文正文' subject='中文摘要' email_from='noreply@easystack.cn'
..
id: 5b220708a24585000d7cfd78
status: succeeded
parameters: 
  account: esdozer
  email_from: noreply@easystack.cn
  email_to:
  - longfei.zhang@easystack.cn
  message: "中文正文"
  subject: "中文摘要"
result: 
  exit_code: 0
  result: null
  stderr: ''
  stdout: ''

```
