### PR TITLE
Unicode fixes for send_email

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # 1.1.0
 
 - Updated to flanker >= 0.9.0
+- Updated send_email.py to support Unicode in subject and message fields
 
 # 1.0.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.1.0
+
+- Updated to flanker >= 0.9.0
+
 # 1.0.3
 
 - Add `attachments` parameter to the send_email action. Expected a list of file paths if given, to be attached to the email.

--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -1,6 +1,7 @@
 import os
 from st2common.runners.base_action import Action
 from smtplib import SMTP
+from email.header import Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -28,10 +29,10 @@ class SendEmail(Action):
                            'Available accounts are: {}'.format(account, ",".join(kv.keys())))
 
         msg = MIMEMultipart()
-        msg['Subject'] = subject
+        msg['Subject'] = Header(subject, 'utf-8')
         msg['From'] = email_from
         msg['To'] = ", ".join(email_to)
-        msg.attach(MIMEText(message, mime))
+        msg.attach(MIMEText(message, mime, 'utf-8'))
 
         attachments = attachments or tuple()
         for filepath in attachments:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - email
   - messaging
   - imap
-version: 1.0.3
+version: 1.1.0
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flanker>=0.4.33
+flanker>=0.9.0
 easyimap>=0.6.1


### PR DESCRIPTION
Incorporated fixes from #16 for Unicode in subject & message, and updated flanker lib to address #13 