### PR TITLE
Pin tld version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.1.4
+
+- Pin tld dependency to <0.11 for Python < 3.0
+
 # 1.1.3
 
 - Minor linting fixes

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - email
   - messaging
   - imap
-version: 1.1.3
+version: 1.1.4
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+tld<0.11; python_version < '3.0'
+tld
 flanker>=0.9.0
 easyimap>=0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tld<0.11; python_version < '3.0'
-tld
+tld; python_version >= '3.0'
 flanker>=0.9.0
 easyimap>=0.6.1


### PR DESCRIPTION
Fixes #27. Supercedes #28.

Specify a Python 2.7-only dependency along with a general dependency in `requirements.txt`:

```
tld<0.11; python_version < '3.0'
tld
```

When installed in an environment with Python < 3.0, it will limit `tld` to `<0.11`. When installed in an environment with Python >= 3.0, it will install any version of `tld`.

Sources:
* https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers
* https://stackoverflow.com/a/33451105