### PR TITLE
add content id for attachments

### DIFF
--- a/actions/send_email.py
+++ b/actions/send_email.py
@@ -16,7 +16,8 @@ class SendEmail(Action):
 
         accounts = self.config.get('smtp_accounts', None)
         if accounts is None:
-            raise ValueError('"smtp_accounts" config value is required to send email.')
+            raise ValueError(
+                '"smtp_accounts" config value is required to send email.')
         if not accounts:
             raise ValueError('at least one account is required to send email.')
 
@@ -42,11 +43,14 @@ class SendEmail(Action):
             email_to += email_cc
 
         attachments = attachments or tuple()
-        for filepath in attachments:
-            filename = os.path.basename(filepath)
-            with open(filepath, 'rb') as f:
+        for el in attachments:
+            filename = os.path.basename(el['filePath'])
+            with open(el['filePath'], 'rb') as f:
                 part = MIMEApplication(f.read(), Name=filename)
-            part['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
+            part['Content-Disposition'] = 'attachment; filename="{}"'.format(
+                filename)
+            part['Content-ID'] = '<{}>'.format(el['fileId'])
+
             msg.attach(part)
 
         s = SMTP(account_data['server'], int(account_data['port']), timeout=20)

--- a/actions/send_email.yaml
+++ b/actions/send_email.yaml
@@ -39,5 +39,5 @@
     attachments:
       type: "array"
       items:
-        type: "string"
-      description: "The absolute paths to the files to be included as attachments."
+        type: "Object"
+      description: "Array of object containing the absolute paths to the files and the file id"


### PR DESCRIPTION
Change attachments input from string to object to allow adding of attachment Id
This to allow the attachment ie image to be use in the email body 
example of attachment input :

[{'filePath':'/test1', 'fileId':'test1'}]
