### PR TITLE
docs: fix typo in the example payload to have a valid JSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Example trigger payload:
     "message_id": "<CAJMHEmJs_5hO_PS9huzTAOv60xkTvYz7ETd1=WXFdpa-bzGpUA@mail.gmail.com>",
     "from": "Tomaž Muraus<tomaz@tomaz.me>",
     "to": "Tomaz Muraus <tomaz.muraus@gmail.com>",
-    "subject": "test email with attachment"
+    "subject": "test email with attachment",
     "body": "hello from stackstorm!\n",
     "headers": [
         [


### PR DESCRIPTION
Fixes a small typo in the example payload. There was a `,` missing so that the JSON was no longer valid.

closes: #34 