### PR TITLE
Update polling interval for email sensor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.1.6
+
+- Add ability to update the polling interval of the IMAP sensor using configuration
+
 # 1.1.5
 
 - Add explicit support for Python 2 and 3

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -104,3 +104,8 @@ sensor_smtp_listen_port:
   type: "integer"
   required: false
   default: 1025
+email_polling_interval:
+  description: "Polling interval for IMAP sensor"
+  type: "integer"
+  required: false
+  default: 30

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - email
   - messaging
   - imap
-version: 1.1.5
+version: 1.1.6
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/sensors/imap_sensor.py
+++ b/sensors/imap_sensor.py
@@ -22,13 +22,14 @@ eventlet.monkey_patch(
 DEFAULT_DOWNLOAD_ATTACHMENTS = False
 DEFAULT_MAX_ATTACHMENT_SIZE = 1024
 DEFAULT_ATTACHMENT_DATASTORE_TTL = 1800
+DEFAULT_POLLING_INTERVAL = 30
 
 
 class IMAPSensor(PollingSensor):
-    def __init__(self, sensor_service, config=None, poll_interval=30):
+    def __init__(self, sensor_service, config=None, poll_interval=DEFAULT_POLLING_INTERVAL):
         super(IMAPSensor, self).__init__(sensor_service=sensor_service,
                                          config=config,
-                                         poll_interval=poll_interval)
+                                         poll_interval=self._config.get('email_polling_interval', poll_interval))
 
         self._trigger = 'email.imap.message'
         self._logger = self._sensor_service.get_logger(__name__)

--- a/sensors/imap_sensor.py
+++ b/sensors/imap_sensor.py
@@ -29,7 +29,8 @@ class IMAPSensor(PollingSensor):
     def __init__(self, sensor_service, config=None, poll_interval=DEFAULT_POLLING_INTERVAL):
         super(IMAPSensor, self).__init__(sensor_service=sensor_service,
                                          config=config,
-                                         poll_interval=self._config.get('email_polling_interval', poll_interval))
+                                         poll_interval=self._config.get('email_polling_interval',
+                                                                        poll_interval))
 
         self._trigger = 'email.imap.message'
         self._logger = self._sensor_service.get_logger(__name__)


### PR DESCRIPTION
Add the ability to update the polling interval of the IMAP sensor.
Priority:
1. Config value
2. Value passed to the constructor of the IMAP sensor
3. The default value, which is set to 30