### PR TITLE
fix python3 issue in IMAPsensor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 2.0.1
+
+- Fix Python 3 related issue in IMAPSensor
+
 # 2.0.0
 
 * Drop Python 2.7 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - email
   - messaging
   - imap
-version: 2.0.0
+version: 2.0.1
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/sensors/imap_sensor.py
+++ b/sensors/imap_sensor.py
@@ -1,6 +1,6 @@
 import hashlib
 import base64
-
+import sys
 import six
 import eventlet
 import easyimap
@@ -130,7 +130,10 @@ class IMAPSensor(PollingSensor):
 
     def _process_message(self, uid, mailbox, mailbox_metadata,
                          download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
-        message = mailbox.mail(uid, include_raw=True)
+        if (sys.version_info > (3, 0)):
+            message = mailbox.mail(str(uid), include_raw=True)
+        else:
+            message = mailbox.mail(uid, include_raw=True)
         mime_msg = mime.from_string(message.raw)
 
         body = message.body

--- a/sensors/imap_sensor.py
+++ b/sensors/imap_sensor.py
@@ -1,6 +1,6 @@
 import hashlib
 import base64
-import sys
+
 import six
 import eventlet
 import easyimap
@@ -130,10 +130,7 @@ class IMAPSensor(PollingSensor):
 
     def _process_message(self, uid, mailbox, mailbox_metadata,
                          download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
-        if (sys.version_info > (3, 0)):
-            message = mailbox.mail(str(uid), include_raw=True)
-        else:
-            message = mailbox.mail(uid, include_raw=True)
+        message = mailbox.mail(str(uid), include_raw=True)
         mime_msg = mime.from_string(message.raw)
 
         body = message.body


### PR DESCRIPTION
Fixes #36 by simply converting uid to string. This change should be backwards compatible with python2 but I didn't really see the need to test it.